### PR TITLE
add .isSameNode equality checks for Elements

### DIFF
--- a/src/arrays.js
+++ b/src/arrays.js
@@ -1,3 +1,5 @@
+var is = require('./is')
+
 module.exports = function shallowEqualArrays(arrA, arrB) {
   if (arrA === arrB) {
     return true;
@@ -10,7 +12,7 @@ module.exports = function shallowEqualArrays(arrA, arrB) {
   }
 
   for (var i = 0; i < len; i++) {
-    if (arrA[i] !== arrB[i]) {
+    if (!is(arrA[i], arrB[i])) {
       return false;
     }
   }

--- a/src/is.js
+++ b/src/is.js
@@ -1,9 +1,10 @@
 const hasElement = typeof Element !== 'undefined'
 
 module.exports = function is(a, b) {
+  /* istanbul ignore next */
   if (hasElement && a instanceof Element && b instanceof Element) {
     return a.isSameNode(b);
-  } else {
-    return a === b;
   }
+
+  return a === b;
 }

--- a/src/is.js
+++ b/src/is.js
@@ -1,0 +1,9 @@
+const hasElement = typeof Element !== 'undefined'
+
+module.exports = function is(a, b) {
+  if (hasElement && a instanceof Element && b instanceof Element) {
+    return a.isSameNode(b);
+  } else {
+    return a === b;
+  }
+}

--- a/src/is.test.js
+++ b/src/is.test.js
@@ -1,0 +1,51 @@
+var expect = require('chai').expect;
+var is = require('./is');
+
+var val1 = 'string';
+var val2 = 0;
+
+var tests = [
+  {
+    should: 'return true when values are ===',
+    objA: val1,
+    objB: val1,
+    result: true
+  },
+  {
+    should: 'return false when values are !==',
+    objA: val1,
+    objB: val2,
+    result: false
+  }
+];
+
+if (typeof Element !== 'undefined') {
+  var el1 = document.createElement('div');
+  var el2 = document.createElement('div');
+  el2.isSameNode = function (el) { return el === el1 };
+  var el3 = document.createElement('div');
+
+  tests = tests.concat([
+    {
+      should: 'return true when elements are same node',
+      objA: el1,
+      objB: el2,
+      result: true
+    },
+    {
+      should: 'return false when elements are not same node',
+      objA: el1,
+      objB: el3,
+      result: false
+    }
+  ])
+}
+
+
+describe('is', function() {
+  tests.forEach(function(test) {
+    it('should ' + test.should, function() {
+      expect(is(test.objA, test.objB)).to.equal(test.result);
+    });
+  });
+});

--- a/src/objects.js
+++ b/src/objects.js
@@ -1,3 +1,5 @@
+var is = require('./is')
+
 module.exports = function shallowEqualObjects(objA, objB) {
   if (objA === objB) {
     return true;
@@ -14,7 +16,7 @@ module.exports = function shallowEqualObjects(objA, objB) {
   for (var i = 0; i < len; i++) {
     var key = aKeys[i];
 
-    if (objA[key] !== objB[key]) {
+    if (!is(objA[key], objB[key])) {
       return false;
     }
   }


### PR DESCRIPTION
When used in the browser, this addition makes it useful for objects and arrays containing DOM nodes as well.

It is not uncommon to override an element's `.isSameNode(element) -> Boolean` to implement custom caching mechanisms with libraries such as https://github.com/yoshuawuyts/nanomorph.

I had to add one istanbul comment as some code would only run in the browser. If you're interested I can also refactor this test suite to use some tooling that makes it run in node _and_ the browser.