### PR TITLE
fix: errors on non-strictly equal falsy arguments

### DIFF
--- a/src/arrays.js
+++ b/src/arrays.js
@@ -3,6 +3,10 @@ module.exports = function shallowEqualArrays(arrA, arrB) {
     return true;
   }
 
+  if (!arrA || !arrB) {
+    return false;
+  }
+
   var len = arrA.length;
 
   if (arrB.length !== len) {

--- a/src/arrays.test.js
+++ b/src/arrays.test.js
@@ -8,6 +8,18 @@ var obj3 = { technology: 'react' };
 
 var tests = [
   {
+    should: 'return false when A is falsy',
+    arrA: null,
+    arrB: [],
+    result: false
+  },
+  {
+    should: 'return false when B is falsy',
+    arrA: [],
+    arrB: undefined,
+    result: false
+  },
+  {
     should: 'return true when arrays are ===',
     arrA: arr,
     arrB: arr,

--- a/src/objects.js
+++ b/src/objects.js
@@ -3,6 +3,10 @@ module.exports = function shallowEqualObjects(objA, objB) {
     return true;
   }
 
+  if (!objA || !objB) {
+    return false;
+  }
+
   var aKeys = Object.keys(objA);
   var bKeys = Object.keys(objB);
   var len = aKeys.length;

--- a/src/objects.test.js
+++ b/src/objects.test.js
@@ -6,6 +6,18 @@ var obj2 = { language: 'elm' };
 
 var tests = [
   {
+    should: 'return false when A is falsy',
+    objA: null,
+    objB: {},
+    result: false
+  },
+  {
+    should: 'return false when B is falsy',
+    objA: {},
+    objB: undefined,
+    result: false
+  },
+  {
     should: 'return true when objects are ===',
     objA: obj1,
     objB: obj1,


### PR DESCRIPTION
Hi, Misha @moroshko!

I understand you might be busy a bit, but I kindly ask you to accept my addition to your npm package.

It resolves a very common issue, when you compare arguments one of which might be falsy, e.g. `shallowEqual(null, [])` or `shallowEqual({}, undefined)`.

I'm happy to use your micro-package, but it is a pity that I have to wrap it with extra guard checks.

Could you look into it, please?

The tests that were failing before my PR are added too:

<img width="433" alt="screen shot 2019-02-05 at 9 21 48 am" src="https://user-images.githubusercontent.com/1962469/52258546-366c2b00-2928-11e9-9872-31263038af22.png">

Best regards,
Yaroslav.