### PR TITLE
Add esm support

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,7 @@
 {
+  "parserOptions": {
+    "sourceType": "module"
+  },
   "env": {
     "node": true,
     "browser": true,

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ coverage
 .nyc_output
 arrays
 objects
+dist
 npm-debug.log

--- a/README.md
+++ b/README.md
@@ -20,14 +20,14 @@ npm install shallow-equal --save
 ## Usage
 
 ```js
-var shallowEqualArrays = require("shallow-equal/arrays");
+import { shallowEqualArrays } "shallow-equal";
 
 shallowEqualArrays([1, 2, 3], [1, 2, 3]); // => true
 shallowEqualArrays([{ a: 5 }], [{ a: 5 }]); // => false
 ```
 
 ```js
-var shallowEqualObjects = require("shallow-equal/objects");
+import { shallowEqualObjects } from "shallow-equal";
 
 shallowEqualObjects({ a: 5, b: "abc" }, { a: 5, b: "abc" }); // => true
 shallowEqualObjects({ a: 5, b: {} }, { a: 5, b: {} }); // => false

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,18 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@types/estree": {
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "12.0.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.0.7.tgz",
+      "integrity": "sha512-1YKeT4JitGgE4SOzyB9eMwO0nGVNkNEsm9qlIt1Lqm/tG2QEiSMTD4kS3aO6L+w5SClLVxALmIBESK6Mk5wX0A==",
+      "dev": true
+    },
     "acorn": {
       "version": "5.7.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
@@ -397,6 +409,12 @@
       "requires": {
         "ramda": "^0.25.0"
       }
+    },
+    "esm": {
+      "version": "3.2.25",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
+      "dev": true
     },
     "espree": {
       "version": "3.5.4",
@@ -963,7 +981,6 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -1708,8 +1725,7 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "loose-envify": {
           "version": "1.3.0",
@@ -2468,6 +2484,25 @@
       "dev": true,
       "requires": {
         "glob": "^7.1.3"
+      }
+    },
+    "rollup": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.15.0.tgz",
+      "integrity": "sha512-IeZwWTqJHkZpU3zXtY3rtWkeoZc299DN8MOyNtkzlm2PpsZZLmLGlffW5giTRe7z5mhgBYvQKKpFtnnzyDOySw==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "0.0.39",
+        "@types/node": "^12.0.7",
+        "acorn": "^6.1.1"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
+          "integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
+          "dev": true
+        }
       }
     },
     "run-async": {

--- a/package.json
+++ b/package.json
@@ -7,22 +7,29 @@
     "url": "https://github.com/moroshko/shallow-equal.git"
   },
   "author": "Misha Moroshko <michael.moroshko@gmail.com>",
+  "main": "dist/index.cjs.js",
+  "module": "dist/index.esm.js",
   "scripts": {
     "lint": "eslint src",
-    "test": "nyc mocha 'src/*.test.js'",
-    "dist": "rm -rf arrays objects && mkdir arrays objects && cp src/arrays.js arrays/index.js && cp src/objects.js objects/index.js",
+    "test": "nyc mocha -r esm 'src/*.test.js'",
+    "build:objects": "rm -rf objects && rollup -f cjs -i src/objects.js -o objects/index.js",
+    "build:arrays": "rm -rf arrays && rollup -f cjs -i src/arrays.js -o arrays/index.js",
+    "build:cjs": "rollup -f cjs -i src/index.js -o dist/index.cjs.js",
+    "build:esm": "rollup -f esm -i src/index.js -o dist/index.esm.js",
     "prebuild": "npm run lint && npm test",
-    "build": "npm run dist",
+    "build": "npm run build:objects && npm run build:arrays && rm -rf dist && npm run build:cjs && npm run build:esm",
     "preversion": "npm run prebuild",
     "postversion": "git push && git push --tags",
-    "prepublish": "npm run dist"
+    "prepublish": "npm run build"
   },
   "devDependencies": {
     "chai": "^3.5.0",
     "eslint": "^3.4.0",
     "eslint-plugin-mocha": "^4.4.0",
+    "esm": "^3.2.25",
     "mocha": "^3.0.2",
-    "nyc": "^8.1.0"
+    "nyc": "^8.1.0",
+    "rollup": "^1.15.0"
   },
   "files": [
     "arrays",

--- a/src/arrays.js
+++ b/src/arrays.js
@@ -1,4 +1,4 @@
-module.exports = function shallowEqualArrays(arrA, arrB) {
+export default function shallowEqualArrays(arrA, arrB) {
   if (arrA === arrB) {
     return true;
   }
@@ -20,4 +20,4 @@ module.exports = function shallowEqualArrays(arrA, arrB) {
   }
 
   return true;
-};
+}

--- a/src/arrays.test.js
+++ b/src/arrays.test.js
@@ -1,5 +1,5 @@
-var expect = require('chai').expect;
-var shallowEqualArrays = require('./arrays');
+import { expect } from 'chai';
+import shallowEqualArrays from './arrays';
 
 var arr = [1, 2, 3];
 var obj1 = { game: 'chess' };

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,2 @@
+export { default as shallowEqualObjects } from './objects';
+export { default as shallowEqualArrays } from './arrays';

--- a/src/objects.js
+++ b/src/objects.js
@@ -1,4 +1,4 @@
-module.exports = function shallowEqualObjects(objA, objB) {
+export default function shallowEqualObjects(objA, objB) {
   if (objA === objB) {
     return true;
   }
@@ -24,4 +24,4 @@ module.exports = function shallowEqualObjects(objA, objB) {
   }
 
   return true;
-};
+}

--- a/src/objects.test.js
+++ b/src/objects.test.js
@@ -1,5 +1,5 @@
-var expect = require('chai').expect;
-var shallowEqualObjects = require('./objects');
+import { expect } from 'chai';
+import shallowEqualObjects from './objects';
 
 var obj1 = { game: 'chess', year: '1979' };
 var obj2 = { language: 'elm' };


### PR DESCRIPTION
In this diff I saved `shallow-equal/arrays` and `shallow-equal/objects` as is.

Added `./dist/index.cjs.js` for main field and `./dist/index.esm.js` for
module field.

Now user may do this

```js
const shallowEqualObjects = require('shallow-equal/objects');
const shallowEqualArrays = require('shallow-equal/arrays');
const { shallowEqualObjects, shallowEqualArrays } = require('shallow-equal');
import { shallowEqualObjects, shallowEqualArrays } from 'shallow-equal';
```