### PR TITLE
fix: use same-value over strict-equality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -397,6 +397,11 @@
         "safe-buffer": "~5.1.1"
       }
     },
+    "core-js-pure": {
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.6.4.tgz",
+      "integrity": "sha512-epIhRLkXdgv32xIUFaaAry2wdxZYBi6bgM7cB136dzzXXa+dFyRLTZeLUJxnd8ShrmyVXBub63n2NHo2JAt8Cw=="
+    },
     "cp-file": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/cp-file/-/cp-file-6.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -73,5 +73,8 @@
     ],
     "check-coverage": true
   },
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "core-js-pure": "^3.6.4"
+  }
 }

--- a/src/arrays.js
+++ b/src/arrays.js
@@ -1,3 +1,5 @@
+import is from 'core-js-pure/es/object/is';
+
 export default function shallowEqualArrays(arrA, arrB) {
   if (arrA === arrB) {
     return true;
@@ -14,7 +16,7 @@ export default function shallowEqualArrays(arrA, arrB) {
   }
 
   for (var i = 0; i < len; i++) {
-    if (arrA[i] !== arrB[i]) {
+    if (is(arrA[i], arrB[i]) === false) {
       return false;
     }
   }

--- a/src/arrays.test.js
+++ b/src/arrays.test.js
@@ -48,6 +48,18 @@ var tests = [
     arrA: [obj1, obj2, obj3],
     arrB: [obj1, obj2, obj3],
     result: true
+  },
+  {
+    should: 'return true if all corresponding elements pass Object.is',
+    arrA: [Number.NaN],
+    arrB: [0/0],
+    result: true
+  },
+  {
+    should: 'return false if all corresponding elements don\'t pass Object.is',
+    arrA: [-0],
+    arrB: [+0],
+    result: false
   }
 ];
 

--- a/src/objects.js
+++ b/src/objects.js
@@ -1,3 +1,5 @@
+import is from 'core-js-pure/es/object/is';
+
 export default function shallowEqualObjects(objA, objB) {
   if (objA === objB) {
     return true;
@@ -18,7 +20,7 @@ export default function shallowEqualObjects(objA, objB) {
   for (var i = 0; i < len; i++) {
     var key = aKeys[i];
 
-    if (objA[key] !== objB[key] || !Object.prototype.hasOwnProperty.call(objB, key)) {
+    if (is(objA[key], objB[key]) === false || !Object.prototype.hasOwnProperty.call(objB, key)) {
       return false;
     }
   }

--- a/src/objects.test.js
+++ b/src/objects.test.js
@@ -52,6 +52,18 @@ var tests = [
     objA: { first: undefined },
     objB: { second: 'green' },
     result: false
+  },
+  {
+    should: 'return true when all values pass Object.is',
+    objA: { first: Number.NaN },
+    objB: { first: 0/0 },
+    result: true
+  },
+  {
+    should: 'return false when all values don\'t pass Object.is',
+    objA: { first: 0 },
+    objB: { first: -0 },
+    result: false
   }
 ];
 


### PR DESCRIPTION
```diff
-shallowEqualArrays([+0, -0]) === true;
+shallowEqualArrays([+0, -0]) === false;

-shallowEqualArrays([NaN, 0/0]) === false;
+shallowEqualArrays([NaN, 0/0]) === true;
```

I'm trying to replace shallow-equal from [`fbjs` which uses `Object.is`](https://unpkg.com/fbjs@1.0.0/lib/shallowEqual.js) instead of `===`. It looks like this package is mostly used in the react ecosystem so it seems relatively safe to switch to [`same-value` comparison](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Equality_comparisons_and_sameness).