### PR TITLE
feat: support custom comparators

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@types/jest": "^24.0.23",
         "@typescript-eslint/eslint-plugin": "^2.11.0",
         "@typescript-eslint/parser": "^2.11.0",
+        "dequal": "^2.0.3",
         "eslint": "^6.8.0",
         "eslint-plugin-jest": "^23.1.1",
         "eslint-plugin-json": "^2.0.1",
@@ -5571,6 +5572,15 @@
       "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
       "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
       "dev": true
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/detect-newline": {
       "version": "2.1.0",
@@ -21860,6 +21870,12 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
       "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
+      "dev": true
+    },
+    "dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true
     },
     "detect-newline": {

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "@types/jest": "^24.0.23",
     "@typescript-eslint/eslint-plugin": "^2.11.0",
     "@typescript-eslint/parser": "^2.11.0",
+    "dequal": "^2.0.3",
     "eslint": "^6.8.0",
     "eslint-plugin-jest": "^23.1.1",
     "eslint-plugin-json": "^2.0.1",

--- a/src/arrays.ts
+++ b/src/arrays.ts
@@ -1,8 +1,11 @@
+import { Comparator, eq } from "./index";
+
 export type validArrayValue<T> = T[] | null | undefined;
 
 export default function shallowEqualArrays<T>(
   arrA: validArrayValue<T>,
-  arrB: validArrayValue<T>
+  arrB: validArrayValue<T>,
+  comparator: Comparator = eq
 ): boolean {
   if (arrA === arrB) {
     return true;
@@ -19,7 +22,7 @@ export default function shallowEqualArrays<T>(
   }
 
   for (let i = 0; i < len; i++) {
-    if (arrA[i] !== arrB[i]) {
+    if (!comparator(arrA[i], arrB[i])) {
       return false;
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,14 +3,28 @@ import shallowEqualObjects, { validObjectValue } from "./objects";
 
 type Comparable<T> = Record<string, T> | T[] | null | undefined;
 
-function shallowEqual<T extends Comparable<T>>(a: T, b: T): boolean {
+export type Comparator = (a: any, b: any) => boolean;
+export function eq<T>(a: T, b: T): boolean {
+  return a === b;
+}
+
+function shallowEqual<T extends Comparable<T>>(
+  a: T,
+  b: T,
+  comparator: Comparator = eq
+): boolean {
   if (Array.isArray(a) || Array.isArray(b)) {
-    return shallowEqualArrays(a as validArrayValue<T>, b as validArrayValue<T>);
+    return shallowEqualArrays(
+      a as validArrayValue<T>,
+      b as validArrayValue<T>,
+      comparator
+    );
   }
 
   return shallowEqualObjects(
     a as validObjectValue<T>,
-    b as validObjectValue<T>
+    b as validObjectValue<T>,
+    comparator
   );
 }
 

--- a/src/objects.ts
+++ b/src/objects.ts
@@ -1,8 +1,11 @@
+import { Comparator, eq } from "./index";
+
 export type validObjectValue<T> = Record<string, T> | null | undefined;
 
 export default function shallowEqualObjects<T>(
   objA: validObjectValue<T>,
-  objB: validObjectValue<T>
+  objB: validObjectValue<T>,
+  comparator: Comparator = eq
 ): boolean {
   if (objA === objB) {
     return true;
@@ -20,11 +23,9 @@ export default function shallowEqualObjects<T>(
     return false;
   }
 
-  for (let i = 0; i < len; i++) {
-    const key = aKeys[i];
-
+  for (const key of aKeys) {
     if (
-      objA[key] !== objB[key] ||
+      !comparator(objA[key], objB[key]) ||
       !Object.prototype.hasOwnProperty.call(objB, key)
     ) {
       return false;


### PR DESCRIPTION
Implements #2 in the current codebase.

**Is it worth it?**

Not sure. It increases the package size by about 80 bytes:
<img width="247" alt="image" src="https://user-images.githubusercontent.com/39933441/212488857-a0555552-18ee-4cc4-97d3-84ebbfcf9044.png">

More importantly, perhaps, it makes every loop of `shallowEqual*` do a function call rather than use `!==`. If we decide we want this feature, but don't want the cost of the function call, we can instead introduce new `shallowEqualCustom*` functions that have the call, but leave the existing functions alone.