### PR TITLE
fix: reference correct mjs file

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "3.0.0",
   "description": "Typescript-compatible minimalistic shallow equality check for arrays/objects",
   "main": "dist/index.js",
-  "module": "dist/index.modern.js",
+  "module": "dist/index.modern.mjs",
   "source": "src/index.ts",
   "types": "dist/index.d.ts",
   "keywords": [


### PR DESCRIPTION
I had a stale /dist. Did the following:
```
> rm -fr dist
> npm run build
> ls dist
```
and verified that the correct file is indeed `dist/index.modern.mjs` using microbundle.

fix #36 