### PR TITLE
suggestion: validate inputs being of type object, early bail-out if necessary

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -146,11 +146,27 @@ describe("shallowEqual on mixed array/objects", () => {
   });
 });
 
+describe("shallowEqual on primitive values of any type", () => {
+  it("should return false", () => {
+    expect(shallowEqual<any>(1, 2)).toBe(false);
+    expect(shallowEqual<any>(1, 1)).toBe(false);
+    expect(shallowEqual<any>("boris", "johnson")).toBe(false);
+    expect(shallowEqual<any>("boris", "boris")).toBe(false);
+  });
+});
+
 describe("shallowEqualObjects", () => {
   objTests.forEach((test) => {
     it("should " + test.should, () => {
       expect(shallowEqualObjects(test.objA, test.objB)).toEqual(test.result);
     });
+  });
+
+  it("should return false for primitive values of any type", () => {
+    expect(shallowEqualObjects(1 as any, 2 as any)).toBe(false);
+    expect(shallowEqualObjects(1 as any, 1 as any)).toBe(false);
+    expect(shallowEqualObjects("boris" as any, "johnson" as any)).toBe(false);
+    expect(shallowEqualObjects("boris" as any, "boris" as any)).toBe(false);
   });
 });
 
@@ -159,5 +175,12 @@ describe("shallowEqualArrays", () => {
     it("should " + test.should, () => {
       expect(shallowEqualArrays(test.arrA, test.arrB)).toEqual(test.result);
     });
+  });
+
+  it("should return false for primitive values of any type", () => {
+    expect(shallowEqualArrays(1 as any, 2 as any)).toBe(false);
+    expect(shallowEqualArrays(1 as any, 1 as any)).toBe(false);
+    expect(shallowEqualArrays("boris" as any, "johnson" as any)).toBe(false);
+    expect(shallowEqualArrays("boris" as any, "boris" as any)).toBe(false);
   });
 });

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -147,11 +147,11 @@ describe("shallowEqual on mixed array/objects", () => {
 });
 
 describe("shallowEqual on primitive values of any type", () => {
-  it("should return false", () => {
+  it("should act correctly", () => {
     expect(shallowEqual<any>(1, 2)).toBe(false);
-    expect(shallowEqual<any>(1, 1)).toBe(false);
+    expect(shallowEqual<any>(1, 1)).toBe(true);
     expect(shallowEqual<any>("boris", "johnson")).toBe(false);
-    expect(shallowEqual<any>("boris", "boris")).toBe(false);
+    expect(shallowEqual<any>("boris", "boris")).toBe(true);
   });
 });
 
@@ -162,11 +162,11 @@ describe("shallowEqualObjects", () => {
     });
   });
 
-  it("should return false for primitive values of any type", () => {
+  it("should act correctly for primitive values of any type", () => {
     expect(shallowEqualObjects(1 as any, 2 as any)).toBe(false);
-    expect(shallowEqualObjects(1 as any, 1 as any)).toBe(false);
+    expect(shallowEqualObjects(1 as any, 1 as any)).toBe(true);
     expect(shallowEqualObjects("boris" as any, "johnson" as any)).toBe(false);
-    expect(shallowEqualObjects("boris" as any, "boris" as any)).toBe(false);
+    expect(shallowEqualObjects("boris" as any, "boris" as any)).toBe(true);
   });
 });
 
@@ -177,10 +177,10 @@ describe("shallowEqualArrays", () => {
     });
   });
 
-  it("should return false for primitive values of any type", () => {
+  it("should act correctly for primitive values of any type", () => {
     expect(shallowEqualArrays(1 as any, 2 as any)).toBe(false);
-    expect(shallowEqualArrays(1 as any, 1 as any)).toBe(false);
+    expect(shallowEqualArrays(1 as any, 1 as any)).toBe(true);
     expect(shallowEqualArrays("boris" as any, "johnson" as any)).toBe(false);
-    expect(shallowEqualArrays("boris" as any, "boris" as any)).toBe(false);
+    expect(shallowEqualArrays("boris" as any, "boris" as any)).toBe(true);
   });
 });

--- a/src/arrays.ts
+++ b/src/arrays.ts
@@ -12,6 +12,10 @@ export default function shallowEqualArrays(
     return false;
   }
 
+  if (typeof arrA !== "object" || typeof arrB !== "object") {
+    return false;
+  }
+
   const len = arrA.length;
 
   if (arrB.length !== len) {

--- a/src/objects.ts
+++ b/src/objects.ts
@@ -12,6 +12,10 @@ export default function shallowEqualObjects<T>(
     return false;
   }
 
+  if (typeof objA !== "object" || typeof objB !== "object") {
+    return false;
+  }
+
   const aKeys = Object.keys(objA);
   const bKeys = Object.keys(objB);
   const len = aKeys.length;


### PR DESCRIPTION
Hi!
Thank you for maintaining this project.
We've been using it in production for the past 6months as our go-to shallow-equality-check utility.

However, we've recently been bit by a bug caused by our failure to ensure the input parameters we're passing to `shallowEquals` are indeed objects or arrays.

To illustrate, we've had a specific case where the input values were different numbers, unfortunately marked as `any`:

```ts
shallowEqual<any>(1, 2);
// true

shallowEqualObjects(1 as any, 2 as any);
// true

shallowEqualArrays(1 as any, 2 as any);
// true
```

I know this library is meant to be used with input values which the consumer knows are objects, and the library does not aim to provide a shallow-equality-check utility accounting for all the possible types & matching edge-cases.

However, I do believe it would be a valuable addition to introduce a bare minimum `typeof`-based validation at the right place, to avoid consumers treating some non-`object`-typeof values as being "shallow-equal", which is what this PR does.

I believe this direction still matches the project's philosophy since there are a couple of existing, similar-to-some-degree checks in the current implementation, such as loosely checking for falsy values in `shallowEqualArrays` notably.

Thank you for your consideration.